### PR TITLE
Handle URLs inlcuding spaces

### DIFF
--- a/marrie.py
+++ b/marrie.py
@@ -34,7 +34,7 @@ config_file = '''\
 # Examples:
 #   wget --limit-rate=30k -c -O %(file)s %(url)s
 #   curl --limit-rate 30K -C - -o %(file)s %(url)s
-fetch_command = wget -c -O %(file)s %(url)s
+fetch_command = wget -c -O "%(file)s" "%(url)s"
 
 # Player command to play the files
 #


### PR DESCRIPTION
If a URL contains spaces then wget command fails thinking that multiple urls are provided as arguments